### PR TITLE
Descrambler file mask support and UTF16 by default

### DIFF
--- a/KirikiriDescrambler/Program.cs
+++ b/KirikiriDescrambler/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Text;
 
@@ -8,31 +8,33 @@ namespace Arc.Ddsi.KirikiriDescrambler
     {
         public static void Main(string[] args)
         {
-            if (args.Length != 1)
+            if (args.Length < 2)
             {
-                Console.WriteLine("Usage: TextDescramble <file>");
+                Console.WriteLine("Usage: TextDescramble <dir> <*.ext>");
                 return;
             }
 
-            string filePath = args[0];
-            if (!File.Exists(filePath))
+            Console.WriteLine("Directory  : " + args[0]);
+            Console.WriteLine("Files mask : " + args[1]);
+            var ksFiles = Directory.EnumerateFiles(args[0], args[1], SearchOption.AllDirectories);
+            foreach (string filePath in ksFiles)
             {
-                Console.WriteLine("Specified file does not exist.");
-                return;
+                Console.WriteLine("Parsing    : " + filePath);
+                //Directory.Move(filePath, Path.Combine(args[0] + "\\backup", filePath));
+                try
+                {
+                    string content = Descrambler.Descramble(filePath);
+                    if (content == null || content == "")
+                        return;
+                    File.WriteAllText(filePath, content, Encoding.Unicode);// Encoding.UTF8);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(ex.Message);
+                }
             }
 
-            try
-            {
-                string content = Descrambler.Descramble(filePath);
-                if (content == null)
-                    return;
 
-                File.WriteAllText(filePath, content, Encoding.UTF8);
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine(ex.Message);
-            }
         }
     }
 }

--- a/KirikiriTools.sln
+++ b/KirikiriTools.sln
@@ -15,6 +15,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Common", "Common\Common.vcx
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KirikiriDescrambler", "KirikiriDescrambler\KirikiriDescrambler.csproj", "{FAEAFEB2-29FF-4229-8E84-9C6FA7422F0F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TextUTF16y", "TextUTF16y\TextUTF16y.csproj", "{FAEAFEB2-29FF-4229-8E84-9C6FA7422F0E}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Common\Common.vcxitems*{68fd9bd1-b4e9-4c34-bbb4-45ed49ee6315}*SharedItemsImports = 4
@@ -46,6 +48,10 @@ Global
 		{FAEAFEB2-29FF-4229-8E84-9C6FA7422F0F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FAEAFEB2-29FF-4229-8E84-9C6FA7422F0F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FAEAFEB2-29FF-4229-8E84-9C6FA7422F0F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FAEAFEB2-29FF-4229-8E84-9C6FA7422F0E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FAEAFEB2-29FF-4229-8E84-9C6FA7422F0E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FAEAFEB2-29FF-4229-8E84-9C6FA7422F0E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FAEAFEB2-29FF-4229-8E84-9C6FA7422F0E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/KirikiriUnencryptedArchiveLauncher/main.cpp
+++ b/KirikiriUnencryptedArchiveLauncher/main.cpp
@@ -1,4 +1,6 @@
 #include "stdafx.h"
+#define _CRT_SECURE_NO_WARNINGS
+#include <shellapi.h>
 
 using namespace std;
 
@@ -44,7 +46,19 @@ wstring GetKirikiriExePath()
 
 int __stdcall wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, wchar_t* pszCmdLine, int cmdShow)
 {
-    wstring exePath = GetKirikiriExePath();
+    int numArgs;
+    wstring exePath;
+    PWSTR *ppszArgs = CommandLineToArgvW(pszCmdLine, &numArgs);
+
+    if (numArgs == 1)
+    {
+        exePath = ppszArgs[0];
+    } 
+    else
+    {
+        exePath = GetKirikiriExePath();
+    }
+
     if (exePath.empty())
     {
         MessageBox(nullptr, L"No Kirikiri .exe found.", L"", MB_ICONEXCLAMATION);
@@ -77,5 +91,10 @@ int __stdcall wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, wchar_t* ps
     );
     CloseHandle(procInfo.hProcess);
     CloseHandle(procInfo.hThread);
+    if (ppszArgs)
+    {
+        LocalFree(ppszArgs);
+    }
+
     return 0;
 }

--- a/README.md
+++ b/README.md
@@ -2,17 +2,26 @@
 Tools for the Kirikiri visual novel engine.
 
 ## KirikiriDescrambler
-Some Kirikiri games have their plaintext scripts (.ks/.tjs) scrambled or compressed. Such files can be recognized by the signature "FE FE XX FF FE" at the start, XX being 00, 01 or 02. KirikiriDescrambler turns them into regular text files which can be placed right back in the game - no rescrambling needed.
+Some Kirikiri games have their plaintext scripts (.ks/.tjs) scrambled or compressed. Such files can be recognized by the signature `FE FE XX FF FE` at the start, `XX` being `00`, `01` or `02`. KirikiriDescrambler turns them into regular text files which can be placed right back in the game - no rescrambling needed.
+
+Usage: `KirikiriDescrambler .\data *.ks`
 
 ## KirikiriUnencryptedArchive
 A Kirikiri plugin (.tpm) which makes games accept unencrypted .xp3 archives. By using this plugin, it's no longer necessary to identify and replicate the encryption for each game you work on; just create an unencrypted archive with the Xp3Pack tool (included in this repository), throw the .tpm in the game's "plugin" folder, and you're done.
 
 ## KirikiriUnencryptedArchiveLauncher
-Kirikiri games with the "CxDec" protection don't load .tpm plugins (they can be recognized by the absence of any .tpm files in the "plugin" folder). Because of this restriction, the KirikiriUnencryptedArchive plugin won't be loaded and unencrypted archives will be ignored. As a workaround, place this launcher .exe in the game's folder and use that rather than starting the game directly. It will find the Kirikiri .exe and launch it with the plugin already in memory.
+Kirikiri games with the "CxDec" protection don't load .tpm plugins (they can be recognized by the absence of any .tpm files in the `plugin` folder). Because of this restriction, the KirikiriUnencryptedArchive plugin won't be loaded and unencrypted archives will be ignored. As a workaround, place this launcher .exe in the game's folder and use that rather than starting the game directly. It will find the Kirikiri .exe automatically and launch it with the plugin already in memory.
 
 For Steam games, make sure to uncomment the two SetEnvironmentVariable() calls in main.cpp and fill in the AppId (the number in the game's Steam store URL).
+
+## TextUTF16y
+Some games have their descarambled or plaintext scripts (.ks/.tjs) in Shift_JIS encoding. This causes games to crash on systems with non-Japanese locale. Use this tool to convert scripts to UTF-16LE encoding if game crashes with .tjs or .ks error. Generally it must be used after files are descrambled. 
+
+Usage: `TextUTF16y .\data *.ks`
 
 ## Xp3Pack
 Creates unencrypted .xp3 archives for use with the KirikiriUnencryptedArchive plugin. Unlike other packing tools, it sets all hashes in the file table to zero; this serves as a marker for the plugin to bypass the game's decryption for those files.
 
-Typical usage is to place Xp3Pack.exe in the game folder, create a "patch" subfolder containing the files you want to include, and run "Xp3Pack patch" from the command line. This will create a patch.xp3 in the game folder. If the game already has its own patch.xp3, name your folder "patch2" and run "Xp3Pack patch2" instead. If the game already has a patch2.xp3, name your folder "patch3", and so on.
+Usage: `Xp3Pack patch`
+
+Where `patch` is a subfolder containing the files you want to include. This will create `patch.xp3` in the game folder. If the game already has its own `patch.xp3`, name your folder `patch2` and run `Xp3Pack patch2` instead. If the game already has a `patch2.xp3`, name your folder `patch3`, and so on.

--- a/TextUTF16y/App.config
+++ b/TextUTF16y/App.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+    </startup>
+</configuration>

--- a/TextUTF16y/Program.cs
+++ b/TextUTF16y/Program.cs
@@ -1,0 +1,68 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace Arc.Ddsi.TextUTF16y
+{
+    public static class Program
+    {
+        /// <summary>
+        /// Determines a text file's encoding by analyzing its byte order mark (BOM).
+        /// Defaults to Shift_JIS when detection of the text file's endianness fails.
+        /// </summary>
+        /// <param name="filename">The text file to analyze.</param>
+        /// <returns>The detected encoding.</returns>
+        public static Encoding GetEncoding(string filename)
+        {
+            // Read the BOM
+            var bom = new byte[4];
+            using (var file = new FileStream(filename, FileMode.Open, FileAccess.Read))
+            {
+                file.Read(bom, 0, 4);
+            }
+
+            // Analyze the BOM
+            if (bom[0] == 0x2b && bom[1] == 0x2f && bom[2] == 0x76) return Encoding.UTF7;
+            if (bom[0] == 0xef && bom[1] == 0xbb && bom[2] == 0xbf) return Encoding.UTF8;
+            if (bom[0] == 0xff && bom[1] == 0xfe) return Encoding.Unicode; //UTF-16LE
+            if (bom[0] == 0xfe && bom[1] == 0xff) return Encoding.BigEndianUnicode; //UTF-16BE
+            if (bom[0] == 0 && bom[1] == 0 && bom[2] == 0xfe && bom[3] == 0xff) return Encoding.UTF32;
+            // defaults to Shift_JIS for this project
+            return System.Text.Encoding.GetEncoding(932);
+        }
+
+        public static void Main(string[] args)
+        {
+            if (args.Length < 2)
+            {
+                Console.WriteLine("Usage: TextUTF16y <dir> <*.ext>");
+                return;
+            }
+
+            Console.WriteLine("Directory  : " + args[0]);
+            Console.WriteLine("Files mask : " + args[1]);
+            var ksFiles = Directory.EnumerateFiles(args[0], args[1], SearchOption.AllDirectories);
+            foreach (string filePath in ksFiles)
+            {
+                //Directory.Move(filePath, Path.Combine(args[0] + "\\backup", filePath));
+                try
+                {
+                    Encoding enc = GetEncoding(filePath);
+                    Console.WriteLine("Parsing    : " + filePath + "(" +  enc.WebName + ")");
+                    if (enc == null)
+                        return;
+                    string str = System.IO.File.ReadAllText(filePath, enc);
+                    if (str == null || str == "")
+                        return;
+                    File.WriteAllText(filePath, str, Encoding.Unicode);// Encoding.UTF8);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(ex.Message);
+                }
+            }
+
+
+        }
+    }
+}

--- a/TextUTF16y/Properties/AssemblyInfo.cs
+++ b/TextUTF16y/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("TextUTF16y")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("TextUTF16y")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("faeafeb2-29ff-4229-8e84-9c6fa7422f0e")]
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/TextUTF16y/TextUTF16y.csproj
+++ b/TextUTF16y/TextUTF16y.csproj
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{FAEAFEB2-29FF-4229-8E84-9C6FA7422F0E}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Arc.Ddsi.TextUTF16y</RootNamespace>
+    <AssemblyName>TextUTF16y</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject>Arc.Ddsi.TextUTF16y.Program</StartupObject>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Xp3Pack/Program.cs
+++ b/Xp3Pack/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 
 namespace Arc.Ddsi.Xp3Pack
@@ -7,7 +7,7 @@ namespace Arc.Ddsi.Xp3Pack
     {
         public static void Main(string[] args)
         {
-            if (args.Length != 1)
+            if (args.Length < 1)
             {
                 Console.WriteLine("Usage: Xp3Pack folder");
                 return;
@@ -23,11 +23,13 @@ namespace Arc.Ddsi.Xp3Pack
             string parentFolderPath = Path.GetDirectoryName(folderPath);
             if (parentFolderPath == null)
             {
-                Console.WriteLine("Specified folder does not have a parent folder.");
+                Console.WriteLine("Specified folder does not have a parent folder?!");
                 return;
             }
 
-            string xp3FilePath = Path.Combine(parentFolderPath, Path.GetFileName(folderPath) + ".xp3");
+            string fileName = Path.GetFileName(folderPath) + ".xp3";
+            Console.WriteLine("Creating " + fileName);
+            string xp3FilePath = Path.Combine(parentFolderPath, fileName);
             Xp3ArchiveWriter.Write(folderPath, xp3FilePath);
         }
     }

--- a/Xp3Pack/Xp3Pack.csproj
+++ b/Xp3Pack/Xp3Pack.csproj
@@ -5,7 +5,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{45DCBC40-F6EB-46CF-9D07-C8FFC57728F7}</ProjectGuid>
-    <OutputType>WinExe</OutputType>
+    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Arc.Ddsi.Xp3Pack</RootNamespace>
     <AssemblyName>Xp3Pack</AssemblyName>


### PR DESCRIPTION
Added mask file support. Now it is possible to specify `*.ks` instead of manually providing each name or running it from a batch script.
UTF16LE is now used as file encoding. It behaves nicely with Kirikiri while UTF8 and original Shift_JIS sometimes crash games.
Added tool to convert all files to this encoding even if they originally unscrambled.

**ps:** Please [squash](https://github.blog/2016-04-01-squash-your-commits/) commits into one if you decide to merge. I've added too many commits while using only Github's editor.