### PR TITLE
Fixed Console output on Windows

### DIFF
--- a/Xp3Pack/Xp3Pack.csproj
+++ b/Xp3Pack/Xp3Pack.csproj
@@ -5,7 +5,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{45DCBC40-F6EB-46CF-9D07-C8FFC57728F7}</ProjectGuid>
-    <OutputType>WinExe</OutputType>
+    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Arc.Ddsi.Xp3Pack</RootNamespace>
     <AssemblyName>Xp3Pack</AssemblyName>


### PR DESCRIPTION
Changed Xp3Pack project output type to Console Application (<OutputType>Exe</OutputType>) instead of Windows Application (<OutputType>WinExe</OutputType>).
Fixes "Console.WriteLine()" calls which don't output to console when project output type is set to WinExe.